### PR TITLE
Update Checkout Version(@abadr99) 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
   dev-style-checking:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Dev-Style-Check 
       run:  make -C dev cpplint
   test-style-checking:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test-Style-Check
       run:  make -C tests cpplint
 
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [dev-style-checking, test-style-checking]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Configure Building
       run: sh /home/runner/work/stm32f10xxx_cpp_interface/stm32f10xxx_cpp_interface/tools/github/configure.sh
     - name: Building For STM32f103 Target
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [dev-style-checking, test-style-checking, build]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Configure gtest
       run: sh /home/runner/work/stm32f10xxx_cpp_interface/stm32f10xxx_cpp_interface/tools/github/configure-test.sh
     - name: Building tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   dev-style-checking:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Dev-Style-Check 
       run:  make -C dev cpplint
   test-style-checking:
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [dev-style-checking, test-style-checking]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Configure Building
       run: sh /home/runner/work/stm32f10xxx_cpp_interface/stm32f10xxx_cpp_interface/tools/github/configure.sh
     - name: Building For STM32f103 Target
       run: make -C dev build
     - name: Upload objects artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: objects-artifact
         path: /home/runner/work/stm32f10xxx_cpp_interface/stm32f10xxx_cpp_interface/dev/.build/
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [dev-style-checking, test-style-checking, build]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Configure gtest
       run: sh /home/runner/work/stm32f10xxx_cpp_interface/stm32f10xxx_cpp_interface/tools/github/configure-test.sh
     - name: Building tests


### PR DESCRIPTION
According github updates we need to update checkout version.

**see:** https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/